### PR TITLE
fix(verde): serde macro features and locations

### DIFF
--- a/compiler/verde/derive/src/database.rs
+++ b/compiler/verde/derive/src/database.rs
@@ -15,10 +15,18 @@ pub(crate) fn storage(input: ItemStruct) -> Result<TokenStream> {
 		})
 		.collect::<std::result::Result<Vec<_>, _>>()
 		.map_err(|_: TryFromIntError| Error::new(name.span(), "how do you have more than 65536 fields?"))?;
+	let derive = if cfg!(feature = "serde") {
+		quote! {
+			#[derive(::verde::serde::Serialize, ::verde::serde::Deserialize)]
+			#[serde(crate = "::verde::serde")]
+		}
+	} else {
+		quote! {}
+	};
 
 	Ok(quote! {
 		#[derive(Default)]
-		#[cfg_attr(feature = "serde", derive(::verde::serde::Serialize, ::verde::serde::Deserialize))]
+		#derive
 		#vis struct #name(
 			#(<#fields as ::verde::internal::Storable>::Storage,)*
 		);
@@ -81,7 +89,10 @@ pub(crate) fn database(input: ItemStruct) -> Result<TokenStream> {
 		.map_err(|_| Error::new(name.span(), "how do you have more than 65536 fields?"))?;
 
 	let derive = if cfg!(feature = "serde") {
-		quote! { #[derive(::verde::serde::Serialize, ::verde::serde::Deserialize)] }
+		quote! {
+            #[derive(::verde::serde::Serialize, ::verde::serde::Deserialize)]
+            #[serde(crate = "::verde::serde")]
+        }
 	} else {
 		quote! {}
 	};

--- a/compiler/verde/derive/src/query.rs
+++ b/compiler/verde/derive/src/query.rs
@@ -62,6 +62,7 @@ pub(crate) fn query(input: ItemFn) -> Result<TokenStream> {
 	let derive = if cfg!(feature = "serde") {
 		quote! {
 			#[derive(::verde::serde::Serialize, ::verde::serde::Deserialize)]
+            #[serde(crate = "::verde::serde")]
 		}
 	} else {
 		quote! {}


### PR DESCRIPTION
1. The #[verde::storage] macro incorrectly uses #[cfg(feature = "serde")] on the derives for `Serialize` and `Deserialize`, causing them not be applied, as that searches in the end-user crate and not verde itself. This changes it to conditionally apply the derive from verde's side.

2. Use `#[serde(crate = "::verde::serde")]` so that downstream crates do not necessarily need `serde` in their dependency lists.